### PR TITLE
Add secrets.yml using dotenv-rails

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -1,0 +1,2 @@
+GOOGLE_CLIENT_ID=your_id
+GOOGLE_CLIENT_SECRET=your_secret

--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,6 @@ db/*.sqlite3
 
 # add /config/database.yml if it contains passwords
 config/database.yml
-config/secrets.yml
 
 # various artifacts
 **.war

--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ group :development, :test do
   gem 'web-console', '~> 2.0'
   gem 'better_errors'
   gem 'spring'
+  gem 'dotenv-rails'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,10 @@ GEM
       railties (>= 4.1.0, < 5.1)
       responders
       warden (~> 1.2.3)
+    dotenv (2.1.1)
+    dotenv-rails (2.1.1)
+      dotenv (= 2.1.1)
+      railties (>= 4.0, < 5.1)
     erubis (2.7.0)
     execjs (2.6.0)
     faraday (0.9.2)
@@ -228,6 +232,7 @@ DEPENDENCIES
   byebug
   coffee-rails (~> 4.1.0)
   devise
+  dotenv-rails
   html2slim
   jbuilder (~> 2.0)
   jquery-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,7 +94,7 @@ GEM
     kaminari-bootstrap (3.0.1)
       kaminari (>= 0.13.0)
       rails
-    libv8 (3.16.14.13)
+    libv8 (3.16.14.15)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.4)

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -1,0 +1,28 @@
+# Be sure to restart your server when you modify this file.
+
+# Your secret key is used for verifying the integrity of signed cookies.
+# If you change this key, all old signed cookies will become invalid!
+
+# Make sure the secret is at least 30 characters and all random,
+# no regular words or you'll be exposed to dictionary attacks.
+# You can use `rake secret` to generate a secure secret key.
+
+# Make sure the secrets in this file are kept private
+# if you're sharing your code publicly.
+
+common: &default_settings
+  google_client_id: <%= ENV["GOOGLE_CLIENT_ID"] %>
+  google_client_secret: <%= ENV["GOOGLE_CLIENT_SECRET"] %>
+
+development:
+  <<: *default_settings
+  secret_key_base: 3a8b56d0eb2ede6445fd2eae65cf2de7bb15d74f7d37a2eca6e783653032078e5509c4cedc76c49761a0b24cf4b721bcb0175503e76b4ab37c28d20de92630ae
+test:
+  <<: *default_settings
+  secret_key_base: bfe96a13ec3d3ae9f8c36064f9c1308a8aa0c0acade0767ce2ef95643acfce2835317b71b7525f699037c1ff7270c4ea4aa2f903426edab278b1dba0343499d6
+
+# Do not keep production secrets in the repository,
+# instead read values from the environment.
+production:
+  <<: *default_settings
+  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>


### PR DESCRIPTION
クレデンシャルな情報はdotenv-railsを使って、`.env`に設定するようにしました。
これによりsecrets.ymlもgithubにコミットできるようにしています。

船津さんがやること
1. このpull reqをマージする
2. ローカルにpull（問題無さそうなら自分の環境にあるsecrets.ymlは上書きする）
3. .env-sample を .env にリネーム
4. .env を開いてAPIのIDとSECRETを設定
5. rails s
6. Googleでログインできることを確認
7. Herokuの環境変数にIDとSECRETを設定
8. Herokuにデプロイ
9. Herokuでログインできることを確認
10. セットアップ手順の修正（secrets.ymlのリネームではなく、.env-sampleのリネームをするように修正）
