### PR TITLE
登校・下校ボタンをトグルで表示させる

### DIFF
--- a/app/controllers/timecards_controller.rb
+++ b/app/controllers/timecards_controller.rb
@@ -5,9 +5,7 @@ class TimecardsController < ApplicationController
   PER = 5
 
   def come
-    @user = current_user
-    @user.timecards.create(timecard_params)
-    if @user.save
+    if current_user.recent_timecard.out? && current_user.timecards.build(timecard_params).save
       redirect_to root_path, notice: 'こんにちは！今日も張り切っていきましょう！'
     else
       redirect_to root_path, notice: '何かエラーが起こったようです...再度お試し下さい'
@@ -27,9 +25,7 @@ class TimecardsController < ApplicationController
   end
 
   def out
-    @user = current_user
-    @user.timecards.create(timecard_params)
-    if @user.save
+    if current_user.recent_timecard.coming? && current_user.timecards.build(timecard_params).save
       redirect_to root_path, notice: 'お疲れ様でした！'
     else
       redirect_to root_path, notice: '何かエラーが起こったようです...再度お試し下さい'

--- a/app/models/timecard.rb
+++ b/app/models/timecard.rb
@@ -1,10 +1,14 @@
 class Timecard < ActiveRecord::Base
+  COMING_TITLE = '登校時刻'.freeze
+  OUT_TITLE = '下校時刻'.freeze
+
   belongs_to :user
-  validate :clock_time_should_be_unique_in_a_day
 
-  private
+  def coming?
+    title == COMING_TITLE
+  end
 
-  def clock_time_should_be_unique_in_a_day
-    return unless title == '登校時間' || title == '下校時間'
+  def out?
+    title == OUT_TITLE
   end
 end

--- a/app/models/timecard.rb
+++ b/app/models/timecard.rb
@@ -4,6 +4,8 @@ class Timecard < ActiveRecord::Base
 
   belongs_to :user
 
+  validates :title, inclusion: { in: [COMING_TITLE, OUT_TITLE] }
+
   def coming?
     title == COMING_TITLE
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,6 +23,6 @@ class User < ActiveRecord::Base
   end
 
   def recent_timecard
-    timecards.order(created_at: :desc).limit(1).first
+    timecards.order(created_at: :desc).first
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,4 +22,7 @@ class User < ActiveRecord::Base
     user
   end
 
+  def recent_timecard
+    timecards.order(created_at: :desc).limit(1).first
+  end
 end

--- a/app/views/layouts/_navigation.html.slim
+++ b/app/views/layouts/_navigation.html.slim
@@ -21,12 +21,14 @@ header.navbar.navbar-default[role="navigation"]
           li.navbar-text.text-muted
             = current_user.name
         - if current_user
-          = form_for current_user.timecards.build, html:{class: 'navbar-form navbar-left'}, url: {controller: :timecards, action: :come} do |f|
-            = f.hidden_field :title, :value => '登校時刻',class:'form-group'
-            = f.button '登校', class: 'btn btn-default', data: {disable_with:'処理中です....'}
-          = form_for current_user.timecards.build, html:{class: 'navbar-form navbar-left'}, url: {controller:  :timecards, action: :out} do |f|
-            = f.hidden_field :title, :value => '下校時刻',class:'form-group'
-            = f.button '下校', class: 'btn btn-default', data: {disable_with:'処理中です....'}
+          - if current_user.recent_timecard.nil? || current_user.recent_timecard.out?
+            = form_for current_user.timecards.build, html:{class: 'navbar-form navbar-left'}, url: {controller: :timecards, action: :come} do |f|
+              = f.hidden_field :title, value: Timecard::COMING_TITLE, class:'form-group'
+              = f.button '登校', class: 'btn btn-default', data: {disable_with:'処理中です....'}
+          - if current_user.recent_timecard.nil? || current_user.recent_timecard.coming?
+            = form_for current_user.timecards.build, html:{class: 'navbar-form navbar-left'}, url: {controller:  :timecards, action: :out} do |f|
+              = f.hidden_field :title, value: Timecard::OUT_TITLE, class:'form-group'
+              = f.button '下校', class: 'btn btn-default', data: {disable_with:'処理中です....'}
           li
             = link_to 'ログアウト', logout_path
         - else

--- a/spec/factories/timecards.rb
+++ b/spec/factories/timecards.rb
@@ -1,0 +1,8 @@
+require 'faker'
+
+FactoryGirl.define do
+  factory :timecard do
+    title Timecard::COMING_TITLE
+    user { create(:user) }
+  end
+end

--- a/spec/models/timecard_spec.rb
+++ b/spec/models/timecard_spec.rb
@@ -32,16 +32,10 @@ describe Timecard do
   end
 
   context "タイトルが想定外の場合" do
-    subject { create(:timecard, title: 'unexpected title') }
-    describe '#coming?' do
-      it 'falseを返す' do
-        expect(subject.coming?).to eq false
-      end
-    end
-
-    describe '#out?' do
-      it 'falseを返す' do
-        expect(subject.out?).to eq false
+    describe '#valid?' do
+      subject { Timecard.new(user: create(:user), title: 'unexpected title') }
+      it 'falseとなること' do
+        expect(subject.valid?).to eq false
       end
     end
   end

--- a/spec/models/timecard_spec.rb
+++ b/spec/models/timecard_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+describe Timecard do
+  context "タイトルが#{Timecard::COMING_TITLE}の場合" do
+    subject { create(:timecard) }
+    describe '#coming?' do
+      it 'trueを返す' do
+        expect(subject.coming?).to eq true
+      end
+    end
+
+    describe '#out?' do
+      it 'falseを返す' do
+        expect(subject.out?).to eq false
+      end
+    end
+  end
+
+  context "タイトルが#{Timecard::OUT_TITLE}の場合" do
+    subject { create(:timecard, title: Timecard::OUT_TITLE) }
+    describe '#coming?' do
+      it 'falseを返す' do
+        expect(subject.coming?).to eq false
+      end
+    end
+
+    describe '#out?' do
+      it 'trueを返す' do
+        expect(subject.out?).to eq true
+      end
+    end
+  end
+
+  context "タイトルが想定外の場合" do
+    subject { create(:timecard, title: 'unexpected title') }
+    describe '#coming?' do
+      it 'falseを返す' do
+        expect(subject.coming?).to eq false
+      end
+    end
+
+    describe '#out?' do
+      it 'falseを返す' do
+        expect(subject.out?).to eq false
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,9 +1,15 @@
 require 'rails_helper'
 
 describe User do
-  # RSpecの動作確認用なので削除して良い
-  example do
-    user = create :user
-    expect(user).to be_valid
+  describe '#recent_timecard' do
+    subject { create(:user) }
+    before do
+      10.times { create(:timecard, user: subject) }
+    end
+
+    it '最新のタイムカードを返す' do
+      last_timecard = Timecard.where(user: subject).order(created_at: :desc).first
+      expect(subject.recent_timecard).to eq last_timecard
+    end
   end
 end


### PR DESCRIPTION
- 直前の登校下校のログを参照し、次に押されるべきボタンだけ表示するようにした
- 直前のログが存在しない場合、両方のボタンを表示する
