### PR TITLE
日付の検証を２つに分けた

### DIFF
--- a/app/models/information.rb
+++ b/app/models/information.rb
@@ -5,16 +5,21 @@ class Information < ActiveRecord::Base
   validates :content, length: { maximum: 2000 }, presence: true
   validates :start_date, presence: true
   validates :expire_date, presence: true
-  validate :expire_date_should_be_before_start_date
+  validate :validate_start_date
+  validate :validate_expire_date
 
   paginates_per 5
 
   private
+  def validate_start_date
+    if start_date <= Time.now
+      errors.add(:start_date ,'は現在時刻以降の値を設定してください')
+    end
+  end
 
-  def expire_date_should_be_before_start_date
-    return unless start_date && expire_date
-    if expire_date >= start_date || expire_date <= Time.now
-      errors.add(:start_date ,'は申し込み期限より後で、現在より後の日時を設定してください')
+  def validate_expire_date
+    if expire_date >= start_date
+      errors.add(:expire_date ,'は開催日時以前の値を設定してください')
     end
   end
 end

--- a/spec/factories/informations.rb
+++ b/spec/factories/informations.rb
@@ -1,0 +1,8 @@
+require 'faker'
+
+FactoryGirl.define do
+  factory :information do
+    title 'タイトル'
+    content '文章'
+  end
+end

--- a/spec/models/information_spec.rb
+++ b/spec/models/information_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe Information do
+  describe '#update' do
+    let(:information) { create(:information, title: 'タイトル',
+                                             content: '内容',
+                                             start_date: Time.now + 2.hour,
+                                             expire_date: Time.now + 1.hour)}
+
+    context '開催日が現在日時より過去の場合' do
+      it 'エラーメッセージを返す' do
+        expect{information.update!(start_date: Time.now)}.to raise_error(ActiveRecord::RecordInvalid, include('開催日は現在時刻以降の値を設定してください'))
+      end
+    end
+
+    context '申し込み期限が開催日時より過去の日時の場合' do
+      it 'エラーメッセージを返す' do
+        expect{information.update!(expire_date: information.start_date + 1.second)}.to raise_error(ActiveRecord::RecordInvalid, 'バリデーションに失敗しました: 申し込み期限は開催日時以前の値を設定してください')
+      end
+    end
+  end
+end

--- a/spec/models/information_spec.rb
+++ b/spec/models/information_spec.rb
@@ -20,8 +20,8 @@ describe Information do
     end
 
     context '申し込み期限が開催日時より未来の日時の場合' do
-      let(:information) { build(:information, start_date: '2016-06-04 16:00'.in_time_zone,
-                                              expire_date: '2016-06-04 16:01'.in_time_zone)}
+      let(:information) { build(:information, start_date: 1.minute.since,
+                                              expire_date: 2.minute.since)}
 
       it 'エラーメッセージを返す' do
         expect(information.valid?).to eq false


### PR DESCRIPTION
日付の検証を２つに分けた
（１）開催日は当日以降を許可する
（２）申し込み期限は開催日以前のみ許可する
