### PR TITLE
お知らせ編集の[参加するか尋ねる]の状態を保存されている値で表示する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ group :test do
   gem "launchy", "~> 2.4"
   gem "selenium-webdriver", "~> 2.43.0"
   gem 'poltergeist', '~> 1.9'
+  gem 'timecop'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -264,6 +264,7 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.2)
+    timecop (0.8.1)
     turbolinks (2.5.3)
       coffee-rails
     tzinfo (1.2.2)
@@ -323,6 +324,7 @@ DEPENDENCIES
   spring-commands-rspec
   sqlite3
   therubyracer
+  timecop
   turbolinks
   uglifier (>= 1.3.0)
   web-console

--- a/app/views/information/edit.html.slim
+++ b/app/views/information/edit.html.slim
@@ -23,5 +23,5 @@
       = f.datetime_select :expire_date, start_year: now.year, end_year: now.year + 1
     .form-group
       = f.label '参加するか尋ねる'
-      = f.check_box :participate,{checked: true}
+      = f.check_box :participate
     = f.submit '更新',class: 'btn btn-default', data: {disable_with:'更新しています...'}

--- a/app/views/information/new.html.slim
+++ b/app/views/information/new.html.slim
@@ -23,5 +23,5 @@
     = f.datetime_select :expire_date, start_year: now.year, end_year: now.year + 1
   .form-group
     = f.label '参加するか尋ねる'
-    = f.check_box :participate,{checked: true}
+    = f.check_box :participate
   = f.submit '作成',class: 'btn btn-default', data: {disable_with:'更新しています...'}

--- a/spec/factories/information.rb
+++ b/spec/factories/information.rb
@@ -1,0 +1,10 @@
+require 'faker'
+
+FactoryGirl.define do
+  factory :information, class: Information  do
+    title 'お知らせ'
+    content 'お知らせ１'
+    start_date 2.day.since
+    expire_date 1.day.since
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -6,4 +6,12 @@ FactoryGirl.define do
     password 'secret1234'
     password_confirmation { password }
   end
+  factory :admin_user, class: User  do
+    name { Faker::Name.name }
+    email 'admin@example.com'
+    password '00000000'
+    password_confirmation { password }
+    admin true
+    confirmed true
+  end
 end

--- a/spec/features/information_spec.rb
+++ b/spec/features/information_spec.rb
@@ -1,0 +1,89 @@
+require 'rails_helper'
+
+feature 'お知らせ新規作成' do
+  let!(:admin_user){ FactoryGirl.create(:admin_user) }
+  before do 
+    visit new_user_session_path
+    fill_in 'Email', with: 'admin@example.com'
+    fill_in 'Password', with: '00000000'
+    click_button 'Log in'
+  end
+  context '参加するか尋ねるがonの場合' do
+    scenario '再度編集画面を表示するとonになっていること' do
+      t = Time.local(2016, 6, 4, 10, 5, 0)
+      Timecop.freeze(t) do
+        visit new_information_path
+        fill_in 'information[title]', with: 'タイトルテスト'
+        fill_in 'information[content]', with: '内容テスト'
+        select '2016',from: 'information[start_date(1i)]'  
+        select '6月',from: 'information[start_date(2i)]'  
+        select '6',from: 'information[start_date(3i)]'  
+        select '2016',from: 'information[expire_date(1i)]'  
+        select '6月',from: 'information[expire_date(2i)]'  
+        select '5',from: 'information[expire_date(3i)]'  
+        check 'information[participate]'
+        click_button '作成'
+        visit edit_information_path(Information.last.id)
+        expect(page).to have_checked_field('information[participate]')
+      end
+    end
+  end
+
+  context '参加するか尋ねるがoffの場合' do
+    scenario '再度編集画面を表示するとoffになっていること' do
+      t = Time.local(2016, 6, 4, 10, 5, 0)
+      Timecop.freeze(t) do
+        visit new_information_path
+        fill_in 'information[title]', with: 'タイトルテスト'
+        fill_in 'information[content]', with: '内容テスト'
+        select '2016',from: 'information[start_date(1i)]'  
+        select '6月',from: 'information[start_date(2i)]'  
+        select '6',from: 'information[start_date(3i)]'  
+        select '2016',from: 'information[expire_date(1i)]'  
+        select '6月',from: 'information[expire_date(2i)]'  
+        select '5',from: 'information[expire_date(3i)]'  
+        uncheck 'information[participate]'
+        click_button '作成'
+        visit edit_information_path(Information.last.id)
+        expect(page).to have_unchecked_field('information[participate]')
+      end
+    end
+  end
+end
+
+feature 'お知らせ編集' do
+  let!(:information){ FactoryGirl.create(:information) }
+  let!(:admin_user){ FactoryGirl.create(:admin_user) }
+  before do 
+    visit new_user_session_path
+    fill_in 'Email', with: 'admin@example.com'
+    fill_in 'Password', with: '00000000'
+    click_button 'Log in'
+  end
+
+  context '参加するか尋ねるがonの場合' do
+    scenario '再度編集画面を表示するとonになっていること' do
+      t = Time.local(2016, 6, 4, 10, 5, 0)
+      Timecop.freeze(t) do
+        visit edit_information_path(information.id)
+        check 'information[participate]'
+        click_button '更新'
+        visit edit_information_path(information.id)
+        expect(page).to have_checked_field('information[participate]')
+      end
+    end
+  end
+
+  context '参加するか尋ねるがoffの場合' do
+    scenario '再度編集画面を表示するとoffになっていること' do
+      t = Time.local(2016, 6, 4, 10, 5, 0)
+      Timecop.freeze(t) do
+        visit edit_information_path(information.id)
+        uncheck 'information[participate]'
+        click_button '更新'
+        visit edit_information_path(information.id)
+        expect(page).to have_unchecked_field('information[participate]')
+      end
+    end
+  end
+end


### PR DESCRIPTION
#55

お知らせ新規作成と編集画面の「参加するか尋ねる」チェックボックスをHTMLの初期値設定を外しました
